### PR TITLE
Refactored the loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 .settings/
 nbactions.xml
 target/
-
+/dist

--- a/pom.xml
+++ b/pom.xml
@@ -220,14 +220,14 @@
 					<includeConfigurationDirectoryInClasspath>true</includeConfigurationDirectoryInClasspath>
 					<programs>
 						<program>
-							<mainClass>loader</mainClass>
+							<mainClass>com.github.sesameloader.LoaderMain</mainClass>
 							<name>load-sesame-native</name>
 							<commandLineArguments>
 								<commandLineArgument>-databaseProvider native</commandLineArgument>
 							</commandLineArguments>
 						</program>
 						<program>
-							<mainClass>loader</mainClass>
+							<mainClass>com.github.sesameloader.LoaderMain</mainClass>
 							<name>load-owlim</name>
 							<commandLineArguments>
 								<commandLineArgument>-databaseProvider owlim</commandLineArgument>
@@ -298,7 +298,7 @@
 				<configuration>
 					<archive>
 						<manifest>
-							<mainClass>loader</mainClass>
+							<mainClass>com.github.sesameloader.LoaderMain</mainClass>
 						</manifest>
 					</archive>
 					<descriptors>

--- a/pom.xml
+++ b/pom.xml
@@ -74,11 +74,19 @@
 		<dependency>
 			<groupId>org.openrdf.sesame</groupId>
 			<artifactId>sesame-rio-rdfxml</artifactId>
+			<scope>runtime</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.openrdf.sesame</groupId>
 			<artifactId>sesame-rio-turtle</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.openrdf.sesame</groupId>
+			<artifactId>sesame-rio-n3</artifactId>
+			<scope>runtime</scope>
 		</dependency>
 
 		<!-- Logging -->
@@ -175,6 +183,12 @@
 				<version>${sesame.version}</version>
 			</dependency>
 		
+			<dependency>
+				<groupId>org.openrdf.sesame</groupId>
+				<artifactId>sesame-rio-n3</artifactId>
+				<version>${sesame.version}</version>
+			</dependency>
+			
 			<!-- Logging -->
 
 			<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,6 @@
 		<dependency>
 			<groupId>org.openrdf.sesame</groupId>
 			<artifactId>sesame-rio-turtle</artifactId>
-			<version>${sesame.version}</version>
 		</dependency>
 
 		<!-- Logging -->
@@ -108,6 +107,11 @@
 		<dependency>
 			<groupId>org.openrdf.sesame</groupId>
 			<artifactId>sesame-sail-nativerdf</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 
@@ -165,6 +169,12 @@
 				<version>${sesame.version}</version>
 			</dependency>
 
+			<dependency>
+				<groupId>org.openrdf.sesame</groupId>
+				<artifactId>sesame-rio-turtle</artifactId>
+				<version>${sesame.version}</version>
+			</dependency>
+		
 			<!-- Logging -->
 
 			<dependency>
@@ -196,6 +206,12 @@
 				<groupId>org.openrdf.sesame</groupId>
 				<artifactId>sesame-sail-nativerdf</artifactId>
 				<version>2.6.3</version>
+			</dependency>
+			<dependency>
+				<groupId>commons-io</groupId>
+				<artifactId>commons-io</artifactId>
+				<version>2.1</version>
+				<scope>test</scope>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/src/main/java/com/github/sesameloader/LoaderMain.java
+++ b/src/main/java/com/github/sesameloader/LoaderMain.java
@@ -24,6 +24,7 @@ import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
 
+import org.openrdf.model.Resource;
 import org.openrdf.model.Statement;
 import org.openrdf.repository.RepositoryException;
 import org.openrdf.rio.RDFFormat;
@@ -58,13 +59,14 @@ public class LoaderMain
      * @param providerType The type of the repository to be used. Currently support "native" and "owlim" as values.
      * @param commitXStatements The number of statements to commit in each transaction.
      * @param threads The number of threads to use for loading.
+     * @param contexts The contexts to put the statements into.
      * @throws SailException If there is a Sail exception thrown during the creation of the repository.
      * @throws RepositoryException If there is a Repository exception thrown during the creation of the repository.
      */
-    public LoaderMain(File dataDir, String providerType, Integer commitXStatements, Integer threads) throws SailException,
+    public LoaderMain(File dataDir, String providerType, Integer commitXStatements, Integer threads, Resource... contexts) throws SailException,
             RepositoryException
     {
-        this(getRepositoryManager(dataDir, providerType), commitXStatements, threads);
+        this(getRepositoryManager(dataDir, providerType), commitXStatements, threads, contexts);
     }
 
     /**
@@ -75,13 +77,14 @@ public class LoaderMain
      * @param nextManager The repository manager to use when accessing the repository.
      * @param commitXStatements The number of statements to commit in each transaction.
      * @param threads The number of threads to use for loading.
+     * @param contexts The contexts to put the statements into.
      * @throws SailException If there is a Sail exception thrown during the creation of the repository.
      * @throws RepositoryException If there is a Repository exception thrown during the creation of the repository.
      */
-    public LoaderMain(RepositoryManager nextManager, Integer commitXStatements, Integer threads) throws SailException, RepositoryException
+    public LoaderMain(RepositoryManager nextManager, Integer commitXStatements, Integer threads, Resource... contexts) throws SailException, RepositoryException
     {
         this.manager = nextManager;
-        createPushers(commitXStatements, threads, manager);
+        createPushers(commitXStatements, threads, manager, contexts);
     }
     
     /**
@@ -142,9 +145,10 @@ public class LoaderMain
      * @param connection The repository manager to use when accessing the repository.
      * @param commitXStatements The number of statements to commit in each transaction.
      * @param threads The number of threads to use for loading.
+     * @param contexts The contexts to put the statements into.
      * @throws RepositoryException
      */
-    private void createPushers(Integer commitEveryXStatements, int threads, RepositoryManager connection)
+    private void createPushers(Integer commitEveryXStatements, int threads, RepositoryManager connection, Resource... contexts)
             throws RepositoryException
     {
         exec = Executors.newFixedThreadPool(threads);
@@ -152,7 +156,7 @@ public class LoaderMain
         for (int i = 0; i < threads; i++)
         {
             final StatementFromQueueIntoRepositoryPusher statementFromQueueIntoRepositoryPusher = new StatementFromQueueIntoRepositoryPusher(queue, commitEveryXStatements,
-                    connection);
+                    connection, contexts);
             pushers.add(statementFromQueueIntoRepositoryPusher);
             exec.submit(statementFromQueueIntoRepositoryPusher);
         }

--- a/src/main/java/com/github/sesameloader/LoaderMain.java
+++ b/src/main/java/com/github/sesameloader/LoaderMain.java
@@ -111,7 +111,7 @@ public class LoaderMain
         }
     }
 
-    private void load(File file, String baseUri)
+    public void load(File file, String baseUri)
             throws FileNotFoundException, IOException, RepositoryException, SailException
     {
 

--- a/src/main/java/com/github/sesameloader/LoaderMain.java
+++ b/src/main/java/com/github/sesameloader/LoaderMain.java
@@ -65,6 +65,8 @@ public class LoaderMain
             RepositoryException
     {
         this(getRepositoryManager(dataDir, providerType), commitXStatements, threads, contexts);
+        
+        log.warn("The repository will not automatically be shutdown. You are responsible for ensuring that the repository manager shuts the repository down correctly after loading");
     }
 
     /**
@@ -81,6 +83,17 @@ public class LoaderMain
     {
         this.manager = nextManager;
         createPushers(commitXStatements, threads, manager, contexts);
+    }
+    
+    /**
+     * This method helps in cases where the manager was created by this class, and otherwise could not be shutdown correctly.
+     * 
+     * @throws SailException
+     * @throws RepositoryException
+     */
+    public void shutdownRepositoryManager() throws SailException, RepositoryException
+    {
+        this.manager.shutDown();
     }
     
     /**

--- a/src/main/java/com/github/sesameloader/LoaderMain.java
+++ b/src/main/java/com/github/sesameloader/LoaderMain.java
@@ -1,3 +1,4 @@
+package com.github.sesameloader;
 /*
  * Copyright Swiss Institute of Bioinformatics (http://www.isb-sib.ch/) (c) 2012.
  *
@@ -34,23 +35,20 @@ import org.openrdf.sail.SailException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.sesameloader.RepositoryManager;
-import com.github.sesameloader.StatementFromQueueIntoRepositoryPusher;
-import com.github.sesameloader.StatementIntoQueuePusher;
 import com.github.sesameloader.owlim.OwlimRepositoryManager;
 import com.github.sesameloader.sesame.NativeRepositoryManager;
 
-public class loader
+public class LoaderMain
 {
 
     private final BlockingQueue<Statement> queue = new ArrayBlockingQueue<Statement>(1000);
-    private final Logger log = LoggerFactory.getLogger(loader.class);
+    private final Logger log = LoggerFactory.getLogger(LoaderMain.class);
     volatile boolean finished = false;
     private ExecutorService exec;
     private final RepositoryManager manager;
     private final List<StatementFromQueueIntoRepositoryPusher> pushers = new ArrayList<StatementFromQueueIntoRepositoryPusher>();
 
-    public loader(File dataDir, Integer commitXStatements, Integer threads, String providerType) throws SailException,
+    public LoaderMain(File dataDir, Integer commitXStatements, Integer threads, String providerType) throws SailException,
             RepositoryException
     {
 
@@ -81,7 +79,7 @@ public class loader
         if (options.has(infile) && options.has(dataFile) && options.has(baseUri) && options.has(commitEveryXStatements)
                 && options.has(threads))
         {
-            final loader loader = new loader(options.valueOf(dataFile), options.valueOf(commitEveryXStatements),
+            final LoaderMain loader = new LoaderMain(options.valueOf(dataFile), options.valueOf(commitEveryXStatements),
                     options.valueOf(threads), options.valueOf(dataBaseProvider));
             loader.load(options.valueOf(infile), options.valueOf(baseUri));
         }

--- a/src/main/java/com/github/sesameloader/LoaderMain.java
+++ b/src/main/java/com/github/sesameloader/LoaderMain.java
@@ -31,6 +31,7 @@ import org.openrdf.rio.RDFHandlerException;
 import org.openrdf.rio.RDFParseException;
 import org.openrdf.rio.RDFParser;
 import org.openrdf.rio.Rio;
+import org.openrdf.rio.UnsupportedRDFormatException;
 import org.openrdf.sail.SailException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,15 +49,53 @@ public class LoaderMain
     private final RepositoryManager manager;
     private final List<StatementFromQueueIntoRepositoryPusher> pushers = new ArrayList<StatementFromQueueIntoRepositoryPusher>();
 
-    public LoaderMain(File dataDir, Integer commitXStatements, Integer threads, String providerType) throws SailException,
+    /**
+     * Creates an instance of the LoaderMain class for a single bulk loading process using the given data directory as the repository location. 
+     * 
+     * The repository is initialised before any loads and shutdown after a single load.
+     * 
+     * @param dataDir The directory where the repository keeps its data files.
+     * @param providerType The type of the repository to be used. Currently support "native" and "owlim" as values.
+     * @param commitXStatements The number of statements to commit in each transaction.
+     * @param threads The number of threads to use for loading.
+     * @throws SailException If there is a Sail exception thrown during the creation of the repository.
+     * @throws RepositoryException If there is a Repository exception thrown during the creation of the repository.
+     */
+    public LoaderMain(File dataDir, String providerType, Integer commitXStatements, Integer threads) throws SailException,
             RepositoryException
     {
-
-        manager = getRepositoryManager(dataDir, providerType);
-        createPushers(commitXStatements, threads, manager);
+        this(getRepositoryManager(dataDir, providerType), commitXStatements, threads);
     }
 
     /**
+     * Creates an instance of the LoaderMain class for a single bulk loading process using the given repository manager to access the repository.
+     * 
+     * The repository manager, and the underlying repository are shutdown after a single load.
+     * 
+     * @param nextManager The repository manager to use when accessing the repository.
+     * @param commitXStatements The number of statements to commit in each transaction.
+     * @param threads The number of threads to use for loading.
+     * @throws SailException If there is a Sail exception thrown during the creation of the repository.
+     * @throws RepositoryException If there is a Repository exception thrown during the creation of the repository.
+     */
+    public LoaderMain(RepositoryManager nextManager, Integer commitXStatements, Integer threads) throws SailException, RepositoryException
+    {
+        this.manager = nextManager;
+        createPushers(commitXStatements, threads, manager);
+    }
+    
+    /**
+     * The main method for this class when run from the command line.
+     * 
+     * Expects the following arguments:
+     * 
+     * infile : The file or directory to load.
+     * dataFile : The location of the repository on the file system.
+     * baseUri : The base URI for all of the files that are being loaded.
+     * commitInterval : The number of statements to aggregate into a single transaction when loading.
+     * pushThreads : The number of threads to use when loading the repository.
+     * databaseProvider : The type of the repository. Currently we support two values for this field, "native" for a Sesame Native repository and "owlim" for an OwlimSchemaRepository.
+     * 
      * @param args
      * @throws IOException
      * @throws FileNotFoundException
@@ -79,13 +118,13 @@ public class LoaderMain
         if (options.has(infile) && options.has(dataFile) && options.has(baseUri) && options.has(commitEveryXStatements)
                 && options.has(threads))
         {
-            final LoaderMain loader = new LoaderMain(options.valueOf(dataFile), options.valueOf(commitEveryXStatements),
-                    options.valueOf(threads), options.valueOf(dataBaseProvider));
+            final LoaderMain loader = new LoaderMain(options.valueOf(dataFile), options.valueOf(dataBaseProvider),
+                    options.valueOf(commitEveryXStatements), options.valueOf(threads));
             loader.load(options.valueOf(infile), options.valueOf(baseUri));
         }
     }
 
-    private RepositoryManager getRepositoryManager(File dataFileLocation, String databaseProvider)
+    public static RepositoryManager getRepositoryManager(File dataFileLocation, String databaseProvider)
             throws RepositoryException, SailException
     {
 
@@ -94,9 +133,17 @@ public class LoaderMain
         else if ("owlim".equalsIgnoreCase(databaseProvider))
             return new OwlimRepositoryManager(dataFileLocation);
         else
-            throw new RuntimeException("Don't know databaseProvider:"+databaseProvider);
+            throw new RuntimeException("Don't know databaseProvider: "+databaseProvider);
     }
 
+    /**
+     * Creates the bulk loader threads using the given parameters and the given repository manager for connections to the repository.
+     * 
+     * @param connection The repository manager to use when accessing the repository.
+     * @param commitXStatements The number of statements to commit in each transaction.
+     * @param threads The number of threads to use for loading.
+     * @throws RepositoryException
+     */
     private void createPushers(Integer commitEveryXStatements, int threads, RepositoryManager connection)
             throws RepositoryException
     {
@@ -111,6 +158,20 @@ public class LoaderMain
         }
     }
 
+    /**
+     * This method loads RDF data in bulk using the given file. If the file is a directory, then every file in the directory will be loaded.
+     * 
+     * The format for the RDF files is determined for each file using the file extension. 
+     * 
+     * The parsers are chosen based on the current registered Sesame Rio parsers.
+     * 
+     * @param file The file or directory to load.
+     * @param baseUri The base URI to use while loading the files.
+     * @throws FileNotFoundException
+     * @throws IOException
+     * @throws RepositoryException
+     * @throws SailException
+     */
     public void load(File file, String baseUri)
             throws FileNotFoundException, IOException, RepositoryException, SailException
     {
@@ -119,9 +180,9 @@ public class LoaderMain
         {
             if (file.isDirectory())
                 for (File infile : file.listFiles())
-                    loadFile(infile, baseUri);
+                    loadFileInternal(infile, baseUri);
             else
-                loadFile(file, baseUri);
+                loadFileInternal(file, baseUri);
             for (StatementFromQueueIntoRepositoryPusher pusher:pushers)
                 pusher.setFinished(true);
             exec.shutdown();
@@ -140,44 +201,128 @@ public class LoaderMain
             manager.shutDown();
         }
     }
+    
+    /**
+     * This method loads RDF data from the given inputStream in bulk, using the given format and baseURI as guides.
+     * 
+     * Note that there must be a parser available in the list of currently loaded Sesame Rio parsers to match the given format.
+     * 
+     * @param stream The input stream containing RDF data
+     * @param format The RDFFormat for the data in the input stream
+     * @param baseUri The base URI to use for the load
+     * @throws IOException Thrown if the stream fails for any reason.
+     * @throws RepositoryException Thrown if there is an error related to the repository
+     * @throws RDFParseException Thrown if the RDF data is not properly formed.
+     * @throws RDFHandlerException Thrown if the bulk statement loader fails for any reason.
+     * @throws SailException Thrown if an underlying Sail for the repository throws an exception.
+     * @throws UnsupportedRDFormatException Thrown if a parser was not currently loaded to match the given format.
+     */
+    public void load(InputStream inputStream, RDFFormat format, String baseUri)
+            throws IOException, RepositoryException, SailException, RDFParseException, RDFHandlerException, UnsupportedRDFormatException
+    {
 
-    private void loadFile(File file, String baseUri)
+        try
+        {
+            loadInputStreamInternal(inputStream, format, baseUri);
+            for (StatementFromQueueIntoRepositoryPusher pusher:pushers)
+                pusher.setFinished(true);
+            exec.shutdown();
+            while (!exec.isTerminated())
+                try
+                {
+                    exec.awaitTermination(1, TimeUnit.SECONDS);
+                } catch (InterruptedException e)
+                {
+                    Thread.currentThread().interrupt();
+                }
+        } finally
+        {
+            for (StatementFromQueueIntoRepositoryPusher pusher:pushers)
+                pusher.setFinished(true);
+            manager.shutDown();
+        }
+    }
+    
+    /**
+     * Internal helper method that loads a single file using the given base URI.
+     * 
+     * This method logs as errors, but does not throw RDFParseException, RDFHandlerException and UnsupportedRDFormatException that occur during the loading process.
+     * 
+     * If you need these exceptions to be thrown, you can use loadInputStreamInternal directly.
+     * 
+     * @param file
+     * @param baseUri
+     * @throws FileNotFoundException
+     * @throws IOException
+     * @throws RepositoryException
+     * @throws SailException
+     */
+    private void loadFileInternal(File file, String baseUri)
             throws FileNotFoundException, IOException, RepositoryException, SailException
     {
         final String name = file.getName();
+        
+        String shortFileName = name;
+        InputStream inputStream = null;
+        
         if (name.endsWith(".gz"))
-            load(new GZIPInputStream(new FileInputStream(file)), name.substring(0, name.length() - 3), baseUri);
+        {
+            inputStream = new GZIPInputStream(new FileInputStream(file));
+            shortFileName = name.substring(0, name.length() - 3);
+        }
         else
-            load(new FileInputStream(file), name, baseUri);
-    }
+        {
+            inputStream = new FileInputStream(file);
+        }
 
-    private void load(InputStream stream, String filename, String baseUri)
-            throws IOException, RepositoryException
-    {
-        RDFFormat format = RDFFormat.forFileName(filename);
+        RDFFormat format = RDFFormat.forFileName(shortFileName);
         if (format == null)
         {
-            log.error("Could not determine RDF format for filename="+filename);
+            log.error("Could not determine RDF format for filename="+shortFileName);
             return;
         }
-        RDFParser rdfParser = Rio.createParser(format);
-        log.debug("parsing " + filename + format.toString());
-        rdfParser.setValueFactory(manager.getConnection().getValueFactory());
-        rdfParser.setVerifyData(false);
-        rdfParser.setPreserveBNodeIDs(false);
-        rdfParser.setRDFHandler(new StatementIntoQueuePusher(queue));
+
+        log.debug("parsing " + shortFileName + " using format " + format.toString());
+        
         try
         {
-            rdfParser.parse(stream, baseUri);
+            loadInputStreamInternal(inputStream, format, baseUri);
         } catch (RDFParseException e)
         {
             log.error(e.getMessage());
         } catch (RDFHandlerException e)
         {
             log.error(e.getMessage());
-        } finally
+        } catch (UnsupportedRDFormatException e)
         {
-            log.info(filename + "read");
+            log.error(e.getMessage());
         }
+        finally
+        {
+            log.info(shortFileName + " read");
+        }
+    }
+
+    /**
+     * Internal helper method that loads RDF in bulk from the given InputStream using the given format and base URI.
+     * 
+     * @param stream The input stream containing RDF data
+     * @param format The RDFFormat for the data in the input stream
+     * @param baseUri The base URI to use for the load
+     * @throws IOException Thrown if the stream fails for any reason.
+     * @throws RepositoryException Thrown if there is an error related to the repository
+     * @throws RDFParseException Thrown if the RDF data is not properly formed.
+     * @throws RDFHandlerException Thrown if the bulk statement loader fails for any reason.
+     * @throws UnsupportedRDFormatException Thrown if a parser was not currently loaded to match the given format.
+     */
+    private void loadInputStreamInternal(InputStream stream, RDFFormat format, String baseUri)
+            throws IOException, RepositoryException, RDFParseException, RDFHandlerException, UnsupportedRDFormatException
+    {    
+        RDFParser rdfParser = Rio.createParser(format);
+        rdfParser.setValueFactory(manager.getConnection().getValueFactory());
+        rdfParser.setVerifyData(false);
+        rdfParser.setPreserveBNodeIDs(false);
+        rdfParser.setRDFHandler(new StatementIntoQueuePusher(queue));
+        rdfParser.parse(stream, baseUri);
     }
 }

--- a/src/main/java/com/github/sesameloader/LoaderMain.java
+++ b/src/main/java/com/github/sesameloader/LoaderMain.java
@@ -319,7 +319,7 @@ public class LoaderMain
             throws IOException, RepositoryException, RDFParseException, RDFHandlerException, UnsupportedRDFormatException
     {    
         RDFParser rdfParser = Rio.createParser(format);
-        rdfParser.setValueFactory(manager.getConnection().getValueFactory());
+        rdfParser.setValueFactory(manager.getValueFactory());
         rdfParser.setVerifyData(false);
         rdfParser.setPreserveBNodeIDs(false);
         rdfParser.setRDFHandler(new StatementIntoQueuePusher(queue));

--- a/src/main/java/com/github/sesameloader/RepositoryManager.java
+++ b/src/main/java/com/github/sesameloader/RepositoryManager.java
@@ -1,5 +1,6 @@
 package com.github.sesameloader;
 
+import org.openrdf.model.ValueFactory;
 import org.openrdf.repository.RepositoryConnection;
 import org.openrdf.repository.RepositoryException;
 import org.openrdf.sail.SailException;
@@ -8,9 +9,11 @@ import org.openrdf.sail.SailException;
 public interface RepositoryManager
 {
 
-	public RepositoryConnection getConnection()
+	RepositoryConnection getConnection()
 	    throws RepositoryException;
 
-	public void shutDown()
+	void shutDown()
 	    throws SailException, RepositoryException;
+	
+	ValueFactory getValueFactory();
 }

--- a/src/main/java/com/github/sesameloader/StatementFromQueueIntoRepositoryPusher.java
+++ b/src/main/java/com/github/sesameloader/StatementFromQueueIntoRepositoryPusher.java
@@ -23,12 +23,12 @@ public class StatementFromQueueIntoRepositoryPusher
 	private Logger log = LoggerFactory.getLogger(StatementFromQueueIntoRepositoryPusher.class);
 
 	public StatementFromQueueIntoRepositoryPusher(BlockingQueue<Statement> queue, int commitEveryStatements,
-	    RepositoryManager connection) throws RepositoryException
+	    RepositoryManager manager) throws RepositoryException
 	{
 		super();
 		this.queue = queue;
 		this.commitEveryStatements = commitEveryStatements;
-		this.connection = connection.getConnection();
+		this.connection = manager.getConnection();
 	}
 
 	@Override
@@ -42,10 +42,20 @@ public class StatementFromQueueIntoRepositoryPusher
 			while (!this.finished || !queue.isEmpty())
 				counter = takeStatementFromQueueAddToConnection(counter);
 			connection.commit();
-                        connection.close();
 		} catch (RepositoryException e)
 		{
 			log.error("Pusher failed " + e.getMessage());
+		}
+		finally
+		{
+            try
+            {
+                connection.close();
+            }
+            catch(RepositoryException e)
+            {
+                log.error("Error closing connection to repository", e);
+            }
 		}
 	}
 

--- a/src/main/java/com/github/sesameloader/StatementFromQueueIntoRepositoryPusher.java
+++ b/src/main/java/com/github/sesameloader/StatementFromQueueIntoRepositoryPusher.java
@@ -3,6 +3,7 @@ package com.github.sesameloader;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
+import org.openrdf.model.Resource;
 import org.openrdf.model.Statement;
 import org.openrdf.repository.RepositoryConnection;
 import org.openrdf.repository.RepositoryException;
@@ -22,13 +23,16 @@ public class StatementFromQueueIntoRepositoryPusher
 
 	private Logger log = LoggerFactory.getLogger(StatementFromQueueIntoRepositoryPusher.class);
 
+    private Resource[] contexts;
+
 	public StatementFromQueueIntoRepositoryPusher(BlockingQueue<Statement> queue, int commitEveryStatements,
-	    RepositoryManager manager) throws RepositoryException
+	    RepositoryManager manager, Resource... contexts) throws RepositoryException
 	{
 		super();
 		this.queue = queue;
 		this.commitEveryStatements = commitEveryStatements;
 		this.connection = manager.getConnection();
+		this.contexts = contexts;
 	}
 
 	@Override
@@ -68,7 +72,7 @@ public class StatementFromQueueIntoRepositoryPusher
 				final Statement st = queue.poll(100, TimeUnit.MILLISECONDS);
 				if (st != null)
 				{
-					connection.add(st);
+					connection.add(st, contexts);
 					counter++;
 					if (counter % commitEveryStatements == 0)
 					{

--- a/src/main/java/com/github/sesameloader/owlim/OwlimRepositoryManager.java
+++ b/src/main/java/com/github/sesameloader/owlim/OwlimRepositoryManager.java
@@ -4,6 +4,8 @@ import com.github.sesameloader.RepositoryManager;
 import com.ontotext.trree.OwlimSchemaRepository;
 import java.io.File;
 import java.util.concurrent.TimeUnit;
+
+import org.openrdf.model.ValueFactory;
 import org.openrdf.repository.RepositoryConnection;
 import org.openrdf.repository.RepositoryException;
 import org.openrdf.repository.sail.SailRepository;
@@ -54,5 +56,11 @@ public class OwlimRepositoryManager
 		//case some other part of a program is interested in it.
                 Thread.interrupted();
             }
+    }
+
+    @Override
+    public ValueFactory getValueFactory()
+    {
+        return repository.getValueFactory();
     }
 }

--- a/src/main/java/com/github/sesameloader/repository/ArbitraryRepositoryManager.java
+++ b/src/main/java/com/github/sesameloader/repository/ArbitraryRepositoryManager.java
@@ -1,0 +1,58 @@
+/**
+ * 
+ */
+package com.github.sesameloader.repository;
+
+import org.openrdf.model.ValueFactory;
+import org.openrdf.repository.Repository;
+import org.openrdf.repository.RepositoryConnection;
+import org.openrdf.repository.RepositoryException;
+import org.openrdf.sail.SailException;
+
+import com.github.sesameloader.RepositoryManager;
+
+/**
+ * @author Peter Ansell p_ansell@yahoo.com
+ *
+ */
+public class ArbitraryRepositoryManager implements RepositoryManager
+{
+    
+    private Repository upstreamRepository;
+
+    /**
+     * Constructs an ArbitraryRepositoryManager as a wrapper around any repository
+     */
+    public ArbitraryRepositoryManager(Repository upstreamRepository)
+    {
+        this.upstreamRepository = upstreamRepository;
+    }
+    
+    /* (non-Javadoc)
+     * @see com.github.sesameloader.RepositoryManager#getConnection()
+     */
+    @Override
+    public RepositoryConnection getConnection() throws RepositoryException
+    {
+        return upstreamRepository.getConnection();
+    }
+    
+    /* (non-Javadoc)
+     * @see com.github.sesameloader.RepositoryManager#shutDown()
+     */
+    @Override
+    public void shutDown() throws SailException, RepositoryException
+    {
+        this.upstreamRepository.shutDown();
+    }
+    
+    /* (non-Javadoc)
+     * @see com.github.sesameloader.RepositoryManager#getValueFactory()
+     */
+    @Override
+    public ValueFactory getValueFactory()
+    {
+        return this.upstreamRepository.getValueFactory();
+    }
+    
+}

--- a/src/main/java/com/github/sesameloader/sail/ArbitrarySailRepositoryManager.java
+++ b/src/main/java/com/github/sesameloader/sail/ArbitrarySailRepositoryManager.java
@@ -1,0 +1,59 @@
+/**
+ * 
+ */
+package com.github.sesameloader.sail;
+
+import org.openrdf.model.ValueFactory;
+import org.openrdf.repository.RepositoryConnection;
+import org.openrdf.repository.RepositoryException;
+import org.openrdf.sail.Sail;
+import org.openrdf.repository.sail.SailRepository;
+import org.openrdf.sail.SailException;
+
+import com.github.sesameloader.RepositoryManager;
+
+/**
+ * @author Peter Ansell p_ansell@yahoo.com
+ *
+ */
+public class ArbitrarySailRepositoryManager implements RepositoryManager
+{
+    
+    private SailRepository upstreamRepository;
+
+    /**
+     * Constructs an ArbitrarySailRepositoryManager as a wrapper around any sail
+     */
+    public ArbitrarySailRepositoryManager(Sail upstreamSail)
+    {
+        this.upstreamRepository = new SailRepository(upstreamSail);
+    }
+    
+    /* (non-Javadoc)
+     * @see com.github.sesameloader.RepositoryManager#getConnection()
+     */
+    @Override
+    public RepositoryConnection getConnection() throws RepositoryException
+    {
+        return this.upstreamRepository.getConnection();
+    }
+    
+    /* (non-Javadoc)
+     * @see com.github.sesameloader.RepositoryManager#shutDown()
+     */
+    @Override
+    public void shutDown() throws SailException, RepositoryException
+    {
+        this.upstreamRepository.shutDown();
+    }
+    
+    /* (non-Javadoc)
+     * @see com.github.sesameloader.RepositoryManager#getValueFactory()
+     */
+    @Override
+    public ValueFactory getValueFactory()
+    {
+        return this.upstreamRepository.getValueFactory();
+    }
+    
+}

--- a/src/main/java/com/github/sesameloader/sesame/NativeRepositoryManager.java
+++ b/src/main/java/com/github/sesameloader/sesame/NativeRepositoryManager.java
@@ -2,6 +2,7 @@ package com.github.sesameloader.sesame;
 
 import java.io.File;
 
+import org.openrdf.model.ValueFactory;
 import org.openrdf.repository.Repository;
 import org.openrdf.repository.RepositoryConnection;
 import org.openrdf.repository.RepositoryException;
@@ -44,5 +45,11 @@ public class NativeRepositoryManager
 	{
 		repository.shutDown();
 	}
+
+    @Override
+    public ValueFactory getValueFactory()
+    {
+        return repository.getValueFactory();
+    }
 
 }

--- a/src/main/java/loader.java
+++ b/src/main/java/loader.java
@@ -158,7 +158,10 @@ public class loader
     {
         RDFFormat format = RDFFormat.forFileName(filename);
         if (format == null)
+        {
+            log.error("Could not determine RDF format for filename="+filename);
             return;
+        }
         RDFParser rdfParser = Rio.createParser(format);
         log.debug("parsing " + filename + format.toString());
         rdfParser.setValueFactory(manager.getConnection().getValueFactory());

--- a/src/test/java/com/github/sesameloader/test/LoaderMainTest.java
+++ b/src/test/java/com/github/sesameloader/test/LoaderMainTest.java
@@ -169,11 +169,15 @@ public class LoaderMainTest
             repositoryManagerBefore.shutDown();
         }
         
+        RepositoryManager repositoryManager = LoaderMain.getRepositoryManager(repositoryFolder, "native");
+        
         LoaderMain loader =
-                new LoaderMain(LoaderMain.getRepositoryManager(repositoryFolder, "native"), new Integer(20),
+                new LoaderMain(repositoryManager, new Integer(20),
                         new Integer(10));
         
         loader.load(testDataFileRdf, "http://test.example.org/test/load/file/native/rdf/base/uri");
+        
+        repositoryManager.shutDown();
         
         // NOTE: LoaderMain automatically shuts down the repository after a single call to load
         
@@ -230,11 +234,15 @@ public class LoaderMainTest
             repositoryManagerBefore.shutDown();
         }
         
+        RepositoryManager repositoryManager = LoaderMain.getRepositoryManager(repositoryFolder, "native");
+        
         LoaderMain loader =
-                new LoaderMain(LoaderMain.getRepositoryManager(repositoryFolder, "native"), new Integer(20),
+                new LoaderMain(repositoryManager, new Integer(20),
                         new Integer(10));
         
         loader.load(testDataFolder, "http://test.example.org/test/load/file/native/rdf/base/uri");
+        
+        repositoryManager.shutDown();
         
         // NOTE: LoaderMain automatically shuts down the repository after a single call to load
         
@@ -296,13 +304,17 @@ public class LoaderMainTest
             repositoryManagerBefore.shutDown();
         }
         
+        RepositoryManager repositoryManager = LoaderMain.getRepositoryManager(repositoryFolder, "native");
+        
         LoaderMain loader =
-                new LoaderMain(LoaderMain.getRepositoryManager(repositoryFolder, "native"), new Integer(20),
+                new LoaderMain(repositoryManager, new Integer(20),
                         new Integer(10));
         
         InputStream testResource1 = this.getClass().getResourceAsStream("loadermaintest-1.rdf");
         
         loader.load(testResource1, RDFFormat.RDFXML, "http://test.example.org/test/load/file/native/rdf/base/uri");
+        
+        repositoryManager.shutDown();
         
         // NOTE: LoaderMain automatically shuts down the repository after a single call to load
         
@@ -360,11 +372,15 @@ public class LoaderMainTest
             repositoryManagerBefore.shutDown();
         }
         
+        RepositoryManager repositoryManager = LoaderMain.getRepositoryManager(repositoryFolder, "native");
+        
         LoaderMain loader =
-                new LoaderMain(LoaderMain.getRepositoryManager(repositoryFolder, "native"), new Integer(20),
+                new LoaderMain(repositoryManager, new Integer(20),
                         new Integer(10));
         
         loader.load(testDataFileN3, "http://test.example.org/test/load/file/native/rdf/base/uri");
+        
+        repositoryManager.shutDown();
         
         // NOTE: LoaderMain automatically shuts down the repository after a single call to load
         
@@ -426,13 +442,17 @@ public class LoaderMainTest
             repositoryManagerBefore.shutDown();
         }
         
+        RepositoryManager repositoryManager = LoaderMain.getRepositoryManager(repositoryFolder, "native");
+        
         LoaderMain loader =
-                new LoaderMain(LoaderMain.getRepositoryManager(repositoryFolder, "native"), new Integer(20),
+                new LoaderMain(repositoryManager, new Integer(20),
                         new Integer(10));
         
         InputStream testResource1 = this.getClass().getResourceAsStream("loadermaintest-1.n3");
         
         loader.load(testResource1, RDFFormat.N3, "http://test.example.org/test/load/file/native/rdf/base/uri");
+        
+        repositoryManager.shutDown();
         
         // NOTE: LoaderMain automatically shuts down the repository after a single call to load
         

--- a/src/test/java/com/github/sesameloader/test/LoaderMainTest.java
+++ b/src/test/java/com/github/sesameloader/test/LoaderMainTest.java
@@ -202,6 +202,67 @@ public class LoaderMainTest
     
     /**
      * Test method for
+     * {@link com.github.sesameloader.test.LoaderMain#load(java.io.File, java.lang.String)}.
+     * 
+     * @throws RepositoryException
+     * @throws SailException
+     * @throws IOException
+     * @throws FileNotFoundException
+     */
+    @Test
+    public void testLoadFileNativeDirectoryMixed() throws SailException, RepositoryException, FileNotFoundException, IOException
+    {
+        RepositoryManager repositoryManagerBefore = LoaderMain.getRepositoryManager(repositoryFolder, "native");
+        
+        RepositoryConnection beforeConnection = null;
+        
+        try
+        {
+            beforeConnection = repositoryManagerBefore.getConnection();
+            Assert.assertEquals(0, beforeConnection.size());
+        }
+        finally
+        {
+            if(beforeConnection != null)
+            {
+                beforeConnection.close();
+            }
+            repositoryManagerBefore.shutDown();
+        }
+        
+        LoaderMain loader =
+                new LoaderMain(LoaderMain.getRepositoryManager(repositoryFolder, "native"), new Integer(20),
+                        new Integer(10));
+        
+        loader.load(testDataFolder, "http://test.example.org/test/load/file/native/rdf/base/uri");
+        
+        // NOTE: LoaderMain automatically shuts down the repository after a single call to load
+        
+        // Therefore, it is okay to create another repository manager here
+        
+        RepositoryManager repositoryManagerAfter = LoaderMain.getRepositoryManager(repositoryFolder, "native");
+        
+        RepositoryConnection afterConnection = null;
+        
+        try
+        {
+            afterConnection = repositoryManagerAfter.getConnection();
+            
+            Assert.assertTrue(afterConnection.size() > 0);
+        }
+        finally
+        {
+            if(afterConnection != null)
+            {
+                afterConnection.close();
+            }
+            
+            repositoryManagerAfter.shutDown();
+        }
+    }
+    
+    /**
+     * Test method for
      * {@link com.github.sesameloader.test.LoaderMain#load(java.io.InputStream, org.openrdf.rio.RDFFormat, java.lang.String)}
      * .
      * 

--- a/src/test/java/com/github/sesameloader/test/LoaderMainTest.java
+++ b/src/test/java/com/github/sesameloader/test/LoaderMainTest.java
@@ -1,0 +1,401 @@
+/**
+ * 
+ */
+package com.github.sesameloader.test;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.openrdf.repository.RepositoryConnection;
+import org.openrdf.repository.RepositoryException;
+import org.openrdf.rio.RDFFormat;
+import org.openrdf.rio.RDFHandlerException;
+import org.openrdf.rio.RDFParseException;
+import org.openrdf.rio.UnsupportedRDFormatException;
+import org.openrdf.sail.SailException;
+
+import com.github.sesameloader.LoaderMain;
+import com.github.sesameloader.RepositoryManager;
+
+/**
+ * @author Peter Ansell p_ansell@yahoo.com
+ * 
+ */
+public class LoaderMainTest
+{
+    
+    /**
+     * JUnit creates this temporary folder before each test and cleans up after each test.
+     * 
+     * All of the test files are located inside of subfolders within folder, so they should all be
+     * cleaned up by JUnit.
+     */
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+    
+    private File repositoryFolder;
+    
+    private File testDataFolder;
+    
+    private File testDataFileRdf;
+    
+    private File testDataFileN3;
+    
+    /**
+     * @throws java.lang.Exception
+     */
+    @Before
+    public void setUp() throws Exception
+    {
+        // create a temporary folder for our test data, which is populated based on resources in the
+        // test jar file
+        testDataFolder = folder.newFolder();
+        
+        // create a randomly named temporary file in RDF/XML format
+        testDataFileRdf = File.createTempFile("loadermaintest-1-", ".rdf", testDataFolder);
+        FileOutputStream testOutputStreamRdf = new FileOutputStream(testDataFileRdf);
+        InputStream testResource1 = this.getClass().getResourceAsStream("loadermaintest-1.rdf");
+        
+        Assert.assertNotNull("Test resource not found", testResource1);
+        
+        IOUtils.copy(testResource1, testOutputStreamRdf);
+        
+        // create a randomly named temporary file in N3 format
+        testDataFileN3 = File.createTempFile("loadermaintest-1-", ".n3", testDataFolder);
+        FileOutputStream testOutputStreamN3 = new FileOutputStream(testDataFileN3);
+        InputStream testResource2 = this.getClass().getResourceAsStream("loadermaintest-1.n3");
+        
+        Assert.assertNotNull("Test resource not found", testResource2);
+        
+        IOUtils.copy(testResource2, testOutputStreamN3);
+        
+        // create a separate folder for the repository data
+        repositoryFolder = folder.newFolder();
+        
+    }
+    
+    /**
+     * @throws java.lang.Exception
+     */
+    @After
+    public void tearDown() throws Exception
+    {
+    }
+    
+    /**
+     * Test method for
+     * {@link com.github.sesameloader.test.LoaderMain#LoaderMain(java.io.File, java.lang.String, java.lang.Integer, java.lang.Integer)}
+     * .
+     * 
+     * @throws RepositoryException
+     * @throws SailException
+     */
+    @Test
+    public void testLoaderMainFileStringIntegerInteger() throws URISyntaxException, SailException, RepositoryException
+    {
+        LoaderMain loader = new LoaderMain(repositoryFolder, "native", new Integer(10), new Integer(5));
+    }
+    
+    /**
+     * Test method for
+     * {@link com.github.sesameloader.test.LoaderMain#LoaderMain(com.github.sesameloader.test.RepositoryManager, java.lang.Integer, java.lang.Integer)}
+     * .
+     * 
+     * @throws RepositoryException
+     * @throws SailException
+     */
+    @Test
+    public void testLoaderMainRepositoryManagerIntegerInteger() throws SailException, RepositoryException
+    {
+        LoaderMain loader =
+                new LoaderMain(LoaderMain.getRepositoryManager(repositoryFolder, "native"), new Integer(20),
+                        new Integer(10));
+    }
+    
+    /**
+     * Test method for
+     * {@link com.github.sesameloader.test.LoaderMain#getRepositoryManager(java.io.File, java.lang.String)}
+     * .
+     * 
+     * @throws SailException
+     * @throws RepositoryException
+     */
+    @Test
+    public void testGetRepositoryManagerNative() throws RepositoryException, SailException
+    {
+        RepositoryManager nativeRepositoryManager = LoaderMain.getRepositoryManager(repositoryFolder, "native");
+        
+        Assert.assertNotNull(nativeRepositoryManager);
+    }
+    
+    /**
+     * Test method for
+     * {@link com.github.sesameloader.test.LoaderMain#load(java.io.File, java.lang.String)}.
+     * 
+     * @throws RepositoryException
+     * @throws SailException
+     * @throws IOException
+     * @throws FileNotFoundException
+     */
+    @Test
+    public void testLoadFileNativeRdf() throws SailException, RepositoryException, FileNotFoundException, IOException
+    {
+        RepositoryManager repositoryManagerBefore = LoaderMain.getRepositoryManager(repositoryFolder, "native");
+        
+        RepositoryConnection beforeConnection = null;
+        
+        try
+        {
+            beforeConnection = repositoryManagerBefore.getConnection();
+            Assert.assertEquals(0, beforeConnection.size());
+        }
+        finally
+        {
+            if(beforeConnection != null)
+            {
+                beforeConnection.close();
+            }
+            repositoryManagerBefore.shutDown();
+        }
+        
+        LoaderMain loader =
+                new LoaderMain(LoaderMain.getRepositoryManager(repositoryFolder, "native"), new Integer(20),
+                        new Integer(10));
+        
+        loader.load(testDataFileRdf, "http://test.example.org/test/load/file/native/rdf/base/uri");
+        
+        // NOTE: LoaderMain automatically shuts down the repository after a single call to load
+        
+        // Therefore, it is okay to create another repository manager here
+        
+        RepositoryManager repositoryManagerAfter = LoaderMain.getRepositoryManager(repositoryFolder, "native");
+        
+        RepositoryConnection afterConnection = null;
+        
+        try
+        {
+            afterConnection = repositoryManagerAfter.getConnection();
+            
+            Assert.assertTrue(afterConnection.size() > 0);
+        }
+        finally
+        {
+            if(afterConnection != null)
+            {
+                afterConnection.close();
+            }
+            
+            repositoryManagerAfter.shutDown();
+        }
+    }
+    
+    /**
+     * Test method for
+     * {@link com.github.sesameloader.test.LoaderMain#load(java.io.InputStream, org.openrdf.rio.RDFFormat, java.lang.String)}
+     * .
+     * 
+     * @throws SailException
+     * @throws RepositoryException
+     * @throws IOException
+     * @throws FileNotFoundException
+     * @throws UnsupportedRDFormatException
+     * @throws RDFHandlerException
+     * @throws RDFParseException
+     */
+    @Test
+    public void testLoadInputStreamRdf() throws RepositoryException, SailException, FileNotFoundException, IOException,
+        RDFParseException, RDFHandlerException, UnsupportedRDFormatException
+    {
+        RepositoryManager repositoryManagerBefore = LoaderMain.getRepositoryManager(repositoryFolder, "native");
+        
+        RepositoryConnection beforeConnection = null;
+        
+        try
+        {
+            beforeConnection = repositoryManagerBefore.getConnection();
+            Assert.assertEquals(0, beforeConnection.size());
+        }
+        finally
+        {
+            if(beforeConnection != null)
+            {
+                beforeConnection.close();
+            }
+            repositoryManagerBefore.shutDown();
+        }
+        
+        LoaderMain loader =
+                new LoaderMain(LoaderMain.getRepositoryManager(repositoryFolder, "native"), new Integer(20),
+                        new Integer(10));
+        
+        InputStream testResource1 = this.getClass().getResourceAsStream("loadermaintest-1.rdf");
+        
+        loader.load(testResource1, RDFFormat.RDFXML, "http://test.example.org/test/load/file/native/rdf/base/uri");
+        
+        // NOTE: LoaderMain automatically shuts down the repository after a single call to load
+        
+        // Therefore, it is okay to create another repository manager here
+        
+        RepositoryManager repositoryManagerAfter = LoaderMain.getRepositoryManager(repositoryFolder, "native");
+        
+        RepositoryConnection afterConnection = null;
+        
+        try
+        {
+            afterConnection = repositoryManagerAfter.getConnection();
+            
+            Assert.assertTrue(afterConnection.size() > 0);
+        }
+        finally
+        {
+            if(afterConnection != null)
+            {
+                afterConnection.close();
+            }
+            
+            repositoryManagerAfter.shutDown();
+        }
+        
+    }
+    
+    /**
+     * Test method for
+     * {@link com.github.sesameloader.test.LoaderMain#load(java.io.File, java.lang.String)}.
+     * 
+     * @throws RepositoryException
+     * @throws SailException
+     * @throws IOException
+     * @throws FileNotFoundException
+     */
+    @Test
+    public void testLoadFileNativeN3() throws SailException, RepositoryException, FileNotFoundException, IOException
+    {
+        RepositoryManager repositoryManagerBefore = LoaderMain.getRepositoryManager(repositoryFolder, "native");
+        
+        RepositoryConnection beforeConnection = null;
+        
+        try
+        {
+            beforeConnection = repositoryManagerBefore.getConnection();
+            Assert.assertEquals(0, beforeConnection.size());
+        }
+        finally
+        {
+            if(beforeConnection != null)
+            {
+                beforeConnection.close();
+            }
+            repositoryManagerBefore.shutDown();
+        }
+        
+        LoaderMain loader =
+                new LoaderMain(LoaderMain.getRepositoryManager(repositoryFolder, "native"), new Integer(20),
+                        new Integer(10));
+        
+        loader.load(testDataFileN3, "http://test.example.org/test/load/file/native/rdf/base/uri");
+        
+        // NOTE: LoaderMain automatically shuts down the repository after a single call to load
+        
+        // Therefore, it is okay to create another repository manager here
+        
+        RepositoryManager repositoryManagerAfter = LoaderMain.getRepositoryManager(repositoryFolder, "native");
+        
+        RepositoryConnection afterConnection = null;
+        
+        try
+        {
+            afterConnection = repositoryManagerAfter.getConnection();
+            
+            Assert.assertTrue(afterConnection.size() > 0);
+        }
+        finally
+        {
+            if(afterConnection != null)
+            {
+                afterConnection.close();
+            }
+            
+            repositoryManagerAfter.shutDown();
+        }
+    }
+    
+    /**
+     * Test method for
+     * {@link com.github.sesameloader.test.LoaderMain#load(java.io.InputStream, org.openrdf.rio.RDFFormat, java.lang.String)}
+     * .
+     * 
+     * @throws SailException
+     * @throws RepositoryException
+     * @throws IOException
+     * @throws FileNotFoundException
+     * @throws UnsupportedRDFormatException
+     * @throws RDFHandlerException
+     * @throws RDFParseException
+     */
+    @Test
+    public void testLoadInputStreamN3() throws RepositoryException, SailException, FileNotFoundException, IOException,
+        RDFParseException, RDFHandlerException, UnsupportedRDFormatException
+    {
+        RepositoryManager repositoryManagerBefore = LoaderMain.getRepositoryManager(repositoryFolder, "native");
+        
+        RepositoryConnection beforeConnection = null;
+        
+        try
+        {
+            beforeConnection = repositoryManagerBefore.getConnection();
+            Assert.assertEquals(0, beforeConnection.size());
+        }
+        finally
+        {
+            if(beforeConnection != null)
+            {
+                beforeConnection.close();
+            }
+            repositoryManagerBefore.shutDown();
+        }
+        
+        LoaderMain loader =
+                new LoaderMain(LoaderMain.getRepositoryManager(repositoryFolder, "native"), new Integer(20),
+                        new Integer(10));
+        
+        InputStream testResource1 = this.getClass().getResourceAsStream("loadermaintest-1.n3");
+        
+        loader.load(testResource1, RDFFormat.N3, "http://test.example.org/test/load/file/native/rdf/base/uri");
+        
+        // NOTE: LoaderMain automatically shuts down the repository after a single call to load
+        
+        // Therefore, it is okay to create another repository manager here
+        
+        RepositoryManager repositoryManagerAfter = LoaderMain.getRepositoryManager(repositoryFolder, "native");
+        
+        RepositoryConnection afterConnection = null;
+        
+        try
+        {
+            afterConnection = repositoryManagerAfter.getConnection();
+            
+            Assert.assertTrue(afterConnection.size() > 0);
+        }
+        finally
+        {
+            if(afterConnection != null)
+            {
+                afterConnection.close();
+            }
+            
+            repositoryManagerAfter.shutDown();
+        }
+        
+    }
+}

--- a/src/test/resources/com/github/sesameloader/test/loadermaintest-1.n3
+++ b/src/test/resources/com/github/sesameloader/test/loadermaintest-1.n3
@@ -1,0 +1,7 @@
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix geo: <http://www.w3.org/2003/01/geo/wgs84_pos#> .
+@prefix edu: <http://www.example.org/> .
+
+<http://www.princeton.edu> geo:lat "40.35" ; geo:long "-74.66" .
+<http://www.cs.princeton.edu> dc:title "Department of Computer Science" .
+<http://www.princeton.edu> edu:hasDept <http://www.cs.princeton.edu> .

--- a/src/test/resources/com/github/sesameloader/test/loadermaintest-1.rdf
+++ b/src/test/resources/com/github/sesameloader/test/loadermaintest-1.rdf
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:geo="http://www. w3.org/2003/01/geo/wgs84_pos#"
+    xmlns:edu="http://www.example.org/">
+
+    <rdf:Description rdf:about="http://www.princeton.edu">
+        <geo:lat>40.35</geo:lat>
+        <geo:long>-74.66</geo:long>
+        <edu:hasDept rdf:resource="http://www.cs.princeton.edu"/>
+    </rdf:Description>
+    
+    <rdf:Description rdf:about="http://www.cs.princeton.edu">
+        <dc:title>Department of Computer Science</dc:title>
+    </rdf:Description>
+
+</rdf:RDF>

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,15 @@
+#
+# This defines the logging level for the rootLogger. It is not required
+# if you are going to keep the level at debug as the rootLogger by default 
+# is at the debug level. The value after the comma is the appender for the
+# root and we have given it the name R
+#
+log4j.rootLogger=DEBUG, R
+
+log4j.appender.R=org.apache.log4j.ConsoleAppender
+log4j.appender.R.layout=org.apache.log4j.PatternLayout
+log4j.appender.R.layout.ConversionPattern=%-5p - %d{dd/MM/yyyy HH:mm:ss} - %m%n
+
+log4j.logger.org.openrdf=TRACE
+
+


### PR DESCRIPTION
Note, this pull request is separate from the previous pull request as you may want to review and comment on this separately. However, until the other pull request is merged, this will contain the commits from the previous pull request.

The refactoring enables the use of the loader in more scenarios than just a command line application with a fixed selection of RepositoryManagers. It is now able to be used for arbitrary RepositoryManager implementations using a new constructor, and for arbitrary InputStreams using a new public load method.

I also added javadoc to the majority of the methods in LoaderMain.
