### PR TITLE
add maximum threads support to repository manager interface

### DIFF
--- a/src/main/java/com/github/sesameloader/LoaderMain.java
+++ b/src/main/java/com/github/sesameloader/LoaderMain.java
@@ -83,7 +83,17 @@ public class LoaderMain
     public LoaderMain(RepositoryManager nextManager, Integer commitXStatements, Integer threads, Resource... contexts) throws SailException, RepositoryException
     {
         this.manager = nextManager;
-        exec = Executors.newFixedThreadPool(threads);
+        
+        if(nextManager.getMaximumThreads() == 0 || threads <= nextManager.getMaximumThreads())
+        {
+            exec = Executors.newFixedThreadPool(threads);
+        }
+        else
+        {
+            log.warn("Tried to select more than the maximum number of threads for the given repository manager");
+            throw new RuntimeException("Tried to select more than the maximum number of threads for the given repository manager");
+        }
+        
         isDone = new CountDownLatch(threads);
         createPushers(commitXStatements, threads, manager, contexts);
     }

--- a/src/main/java/com/github/sesameloader/RepositoryManager.java
+++ b/src/main/java/com/github/sesameloader/RepositoryManager.java
@@ -16,4 +16,16 @@ public interface RepositoryManager
 	    throws SailException, RepositoryException;
 	
 	ValueFactory getValueFactory();
+	
+	/**
+	 * Some repositories do not support more than one or a few threads, 
+	 * or it is much faster to restrict them to one or a few threads.
+	 * 
+	 * This method enables the RepositoryManager to signal this to the 
+	 * loader to avoid slow loading.
+	 * 
+	 * @return The maximum number of threads supported by this 
+	 *     RepositoryManager, or 0 for an arbitrary number of threads.
+	 */
+	Integer getMaximumThreads();
 }

--- a/src/main/java/com/github/sesameloader/owlim/OwlimRepositoryManager.java
+++ b/src/main/java/com/github/sesameloader/owlim/OwlimRepositoryManager.java
@@ -63,4 +63,10 @@ public class OwlimRepositoryManager
     {
         return repository.getValueFactory();
     }
+
+    @Override
+    public Integer getMaximumThreads()
+    {
+        return 0;
+    }
 }

--- a/src/main/java/com/github/sesameloader/repository/ArbitraryRepositoryManager.java
+++ b/src/main/java/com/github/sesameloader/repository/ArbitraryRepositoryManager.java
@@ -54,5 +54,11 @@ public class ArbitraryRepositoryManager implements RepositoryManager
     {
         return this.upstreamRepository.getValueFactory();
     }
+
+    @Override
+    public Integer getMaximumThreads()
+    {
+        return 0;
+    }
     
 }

--- a/src/main/java/com/github/sesameloader/sail/ArbitrarySailRepositoryManager.java
+++ b/src/main/java/com/github/sesameloader/sail/ArbitrarySailRepositoryManager.java
@@ -55,5 +55,11 @@ public class ArbitrarySailRepositoryManager implements RepositoryManager
     {
         return this.upstreamRepository.getValueFactory();
     }
+
+    @Override
+    public Integer getMaximumThreads()
+    {
+        return 0;
+    }
     
 }

--- a/src/main/java/com/github/sesameloader/sesame/NativeRepositoryManager.java
+++ b/src/main/java/com/github/sesameloader/sesame/NativeRepositoryManager.java
@@ -52,4 +52,10 @@ public class NativeRepositoryManager
         return repository.getValueFactory();
     }
 
+    @Override
+    public Integer getMaximumThreads()
+    {
+        return 0;
+    }
+    
 }

--- a/src/test/java/com/github/sesameloader/test/LoaderMainTest.java
+++ b/src/test/java/com/github/sesameloader/test/LoaderMainTest.java
@@ -60,28 +60,28 @@ public class LoaderMainTest
     {
         // create a temporary folder for our test data, which is populated based on resources in the
         // test jar file
-        testDataFolder = folder.newFolder();
+        this.testDataFolder = this.folder.newFolder();
         
         // create a randomly named temporary file in RDF/XML format
-        testDataFileRdf = File.createTempFile("loadermaintest-1-", ".rdf", testDataFolder);
-        FileOutputStream testOutputStreamRdf = new FileOutputStream(testDataFileRdf);
-        InputStream testResource1 = this.getClass().getResourceAsStream("loadermaintest-1.rdf");
+        this.testDataFileRdf = File.createTempFile("loadermaintest-1-", ".rdf", this.testDataFolder);
+        final FileOutputStream testOutputStreamRdf = new FileOutputStream(this.testDataFileRdf);
+        final InputStream testResource1 = this.getClass().getResourceAsStream("loadermaintest-1.rdf");
         
         Assert.assertNotNull("Test resource not found", testResource1);
         
         IOUtils.copy(testResource1, testOutputStreamRdf);
         
         // create a randomly named temporary file in N3 format
-        testDataFileN3 = File.createTempFile("loadermaintest-1-", ".n3", testDataFolder);
-        FileOutputStream testOutputStreamN3 = new FileOutputStream(testDataFileN3);
-        InputStream testResource2 = this.getClass().getResourceAsStream("loadermaintest-1.n3");
+        this.testDataFileN3 = File.createTempFile("loadermaintest-1-", ".n3", this.testDataFolder);
+        final FileOutputStream testOutputStreamN3 = new FileOutputStream(this.testDataFileN3);
+        final InputStream testResource2 = this.getClass().getResourceAsStream("loadermaintest-1.n3");
         
         Assert.assertNotNull("Test resource not found", testResource2);
         
         IOUtils.copy(testResource2, testOutputStreamN3);
         
         // create a separate folder for the repository data
-        repositoryFolder = folder.newFolder();
+        this.repositoryFolder = this.folder.newFolder();
         
     }
     
@@ -95,6 +95,23 @@ public class LoaderMainTest
     
     /**
      * Test method for
+     * {@link com.github.sesameloader.test.LoaderMain#getRepositoryManager(java.io.File, java.lang.String)}
+     * .
+     * 
+     * @throws SailException
+     * @throws RepositoryException
+     */
+    @Test
+    public void testGetRepositoryManagerNative() throws RepositoryException, SailException
+    {
+        final RepositoryManager nativeRepositoryManager =
+                LoaderMain.getRepositoryManager(this.repositoryFolder, "native");
+        
+        Assert.assertNotNull(nativeRepositoryManager);
+    }
+    
+    /**
+     * Test method for
      * {@link com.github.sesameloader.test.LoaderMain#LoaderMain(java.io.File, java.lang.String, java.lang.Integer, java.lang.Integer)}
      * .
      * 
@@ -104,7 +121,7 @@ public class LoaderMainTest
     @Test
     public void testLoaderMainFileStringIntegerInteger() throws URISyntaxException, SailException, RepositoryException
     {
-        LoaderMain loader = new LoaderMain(repositoryFolder, "native", new Integer(10), new Integer(5));
+        final LoaderMain loader = new LoaderMain(this.repositoryFolder, "native", new Integer(10), new Integer(5));
     }
     
     /**
@@ -118,25 +135,9 @@ public class LoaderMainTest
     @Test
     public void testLoaderMainRepositoryManagerIntegerInteger() throws SailException, RepositoryException
     {
-        LoaderMain loader =
-                new LoaderMain(LoaderMain.getRepositoryManager(repositoryFolder, "native"), new Integer(20),
+        final LoaderMain loader =
+                new LoaderMain(LoaderMain.getRepositoryManager(this.repositoryFolder, "native"), new Integer(20),
                         new Integer(10));
-    }
-    
-    /**
-     * Test method for
-     * {@link com.github.sesameloader.test.LoaderMain#getRepositoryManager(java.io.File, java.lang.String)}
-     * .
-     * 
-     * @throws SailException
-     * @throws RepositoryException
-     */
-    @Test
-    public void testGetRepositoryManagerNative() throws RepositoryException, SailException
-    {
-        RepositoryManager nativeRepositoryManager = LoaderMain.getRepositoryManager(repositoryFolder, "native");
-        
-        Assert.assertNotNull(nativeRepositoryManager);
     }
     
     /**
@@ -149,9 +150,11 @@ public class LoaderMainTest
      * @throws FileNotFoundException
      */
     @Test
-    public void testLoadFileNativeRdf() throws SailException, RepositoryException, FileNotFoundException, IOException
+    public void testLoadFileNativeDirectoryMixed() throws SailException, RepositoryException, FileNotFoundException,
+        IOException
     {
-        RepositoryManager repositoryManagerBefore = LoaderMain.getRepositoryManager(repositoryFolder, "native");
+        final RepositoryManager repositoryManagerBefore =
+                LoaderMain.getRepositoryManager(this.repositoryFolder, "native");
         
         RepositoryConnection beforeConnection = null;
         
@@ -169,13 +172,11 @@ public class LoaderMainTest
             repositoryManagerBefore.shutDown();
         }
         
-        RepositoryManager repositoryManager = LoaderMain.getRepositoryManager(repositoryFolder, "native");
+        final RepositoryManager repositoryManager = LoaderMain.getRepositoryManager(this.repositoryFolder, "native");
         
-        LoaderMain loader =
-                new LoaderMain(repositoryManager, new Integer(20),
-                        new Integer(10));
+        final LoaderMain loader = new LoaderMain(repositoryManager, new Integer(20), new Integer(10));
         
-        loader.load(testDataFileRdf, "http://test.example.org/test/load/file/native/rdf/base/uri");
+        loader.load(this.testDataFolder, "http://test.example.org/test/load/file/native/rdf/base/uri");
         
         repositoryManager.shutDown();
         
@@ -183,7 +184,8 @@ public class LoaderMainTest
         
         // Therefore, it is okay to create another repository manager here
         
-        RepositoryManager repositoryManagerAfter = LoaderMain.getRepositoryManager(repositoryFolder, "native");
+        final RepositoryManager repositoryManagerAfter =
+                LoaderMain.getRepositoryManager(this.repositoryFolder, "native");
         
         RepositoryConnection afterConnection = null;
         
@@ -202,144 +204,6 @@ public class LoaderMainTest
             
             repositoryManagerAfter.shutDown();
         }
-    }
-    
-    /**
-     * Test method for
-     * {@link com.github.sesameloader.test.LoaderMain#load(java.io.File, java.lang.String)}.
-     * 
-     * @throws RepositoryException
-     * @throws SailException
-     * @throws IOException
-     * @throws FileNotFoundException
-     */
-    @Test
-    public void testLoadFileNativeDirectoryMixed() throws SailException, RepositoryException, FileNotFoundException, IOException
-    {
-        RepositoryManager repositoryManagerBefore = LoaderMain.getRepositoryManager(repositoryFolder, "native");
-        
-        RepositoryConnection beforeConnection = null;
-        
-        try
-        {
-            beforeConnection = repositoryManagerBefore.getConnection();
-            Assert.assertEquals(0, beforeConnection.size());
-        }
-        finally
-        {
-            if(beforeConnection != null)
-            {
-                beforeConnection.close();
-            }
-            repositoryManagerBefore.shutDown();
-        }
-        
-        RepositoryManager repositoryManager = LoaderMain.getRepositoryManager(repositoryFolder, "native");
-        
-        LoaderMain loader =
-                new LoaderMain(repositoryManager, new Integer(20),
-                        new Integer(10));
-        
-        loader.load(testDataFolder, "http://test.example.org/test/load/file/native/rdf/base/uri");
-        
-        repositoryManager.shutDown();
-        
-        // NOTE: LoaderMain automatically shuts down the repository after a single call to load
-        
-        // Therefore, it is okay to create another repository manager here
-        
-        RepositoryManager repositoryManagerAfter = LoaderMain.getRepositoryManager(repositoryFolder, "native");
-        
-        RepositoryConnection afterConnection = null;
-        
-        try
-        {
-            afterConnection = repositoryManagerAfter.getConnection();
-            
-            Assert.assertTrue(afterConnection.size() > 0);
-        }
-        finally
-        {
-            if(afterConnection != null)
-            {
-                afterConnection.close();
-            }
-            
-            repositoryManagerAfter.shutDown();
-        }
-    }
-    
-    /**
-     * Test method for
-     * {@link com.github.sesameloader.test.LoaderMain#load(java.io.InputStream, org.openrdf.rio.RDFFormat, java.lang.String)}
-     * .
-     * 
-     * @throws SailException
-     * @throws RepositoryException
-     * @throws IOException
-     * @throws FileNotFoundException
-     * @throws UnsupportedRDFormatException
-     * @throws RDFHandlerException
-     * @throws RDFParseException
-     */
-    @Test
-    public void testLoadInputStreamRdf() throws RepositoryException, SailException, FileNotFoundException, IOException,
-        RDFParseException, RDFHandlerException, UnsupportedRDFormatException
-    {
-        RepositoryManager repositoryManagerBefore = LoaderMain.getRepositoryManager(repositoryFolder, "native");
-        
-        RepositoryConnection beforeConnection = null;
-        
-        try
-        {
-            beforeConnection = repositoryManagerBefore.getConnection();
-            Assert.assertEquals(0, beforeConnection.size());
-        }
-        finally
-        {
-            if(beforeConnection != null)
-            {
-                beforeConnection.close();
-            }
-            repositoryManagerBefore.shutDown();
-        }
-        
-        RepositoryManager repositoryManager = LoaderMain.getRepositoryManager(repositoryFolder, "native");
-        
-        LoaderMain loader =
-                new LoaderMain(repositoryManager, new Integer(20),
-                        new Integer(10));
-        
-        InputStream testResource1 = this.getClass().getResourceAsStream("loadermaintest-1.rdf");
-        
-        loader.load(testResource1, RDFFormat.RDFXML, "http://test.example.org/test/load/file/native/rdf/base/uri");
-        
-        repositoryManager.shutDown();
-        
-        // NOTE: LoaderMain automatically shuts down the repository after a single call to load
-        
-        // Therefore, it is okay to create another repository manager here
-        
-        RepositoryManager repositoryManagerAfter = LoaderMain.getRepositoryManager(repositoryFolder, "native");
-        
-        RepositoryConnection afterConnection = null;
-        
-        try
-        {
-            afterConnection = repositoryManagerAfter.getConnection();
-            
-            Assert.assertTrue(afterConnection.size() > 0);
-        }
-        finally
-        {
-            if(afterConnection != null)
-            {
-                afterConnection.close();
-            }
-            
-            repositoryManagerAfter.shutDown();
-        }
-        
     }
     
     /**
@@ -354,7 +218,8 @@ public class LoaderMainTest
     @Test
     public void testLoadFileNativeN3() throws SailException, RepositoryException, FileNotFoundException, IOException
     {
-        RepositoryManager repositoryManagerBefore = LoaderMain.getRepositoryManager(repositoryFolder, "native");
+        final RepositoryManager repositoryManagerBefore =
+                LoaderMain.getRepositoryManager(this.repositoryFolder, "native");
         
         RepositoryConnection beforeConnection = null;
         
@@ -372,13 +237,11 @@ public class LoaderMainTest
             repositoryManagerBefore.shutDown();
         }
         
-        RepositoryManager repositoryManager = LoaderMain.getRepositoryManager(repositoryFolder, "native");
+        final RepositoryManager repositoryManager = LoaderMain.getRepositoryManager(this.repositoryFolder, "native");
         
-        LoaderMain loader =
-                new LoaderMain(repositoryManager, new Integer(20),
-                        new Integer(10));
+        final LoaderMain loader = new LoaderMain(repositoryManager, new Integer(20), new Integer(10));
         
-        loader.load(testDataFileN3, "http://test.example.org/test/load/file/native/rdf/base/uri");
+        loader.load(this.testDataFileN3, "http://test.example.org/test/load/file/native/rdf/base/uri");
         
         repositoryManager.shutDown();
         
@@ -386,7 +249,73 @@ public class LoaderMainTest
         
         // Therefore, it is okay to create another repository manager here
         
-        RepositoryManager repositoryManagerAfter = LoaderMain.getRepositoryManager(repositoryFolder, "native");
+        final RepositoryManager repositoryManagerAfter =
+                LoaderMain.getRepositoryManager(this.repositoryFolder, "native");
+        
+        RepositoryConnection afterConnection = null;
+        
+        try
+        {
+            afterConnection = repositoryManagerAfter.getConnection();
+            
+            Assert.assertTrue(afterConnection.size() > 0);
+        }
+        finally
+        {
+            if(afterConnection != null)
+            {
+                afterConnection.close();
+            }
+            
+            repositoryManagerAfter.shutDown();
+        }
+    }
+    
+    /**
+     * Test method for
+     * {@link com.github.sesameloader.test.LoaderMain#load(java.io.File, java.lang.String)}.
+     * 
+     * @throws RepositoryException
+     * @throws SailException
+     * @throws IOException
+     * @throws FileNotFoundException
+     */
+    @Test
+    public void testLoadFileNativeRdf() throws SailException, RepositoryException, FileNotFoundException, IOException
+    {
+        final RepositoryManager repositoryManagerBefore =
+                LoaderMain.getRepositoryManager(this.repositoryFolder, "native");
+        
+        RepositoryConnection beforeConnection = null;
+        
+        try
+        {
+            beforeConnection = repositoryManagerBefore.getConnection();
+            Assert.assertEquals(0, beforeConnection.size());
+        }
+        finally
+        {
+            if(beforeConnection != null)
+            {
+                beforeConnection.close();
+            }
+            repositoryManagerBefore.shutDown();
+        }
+        
+        final RepositoryManager repositoryManager = LoaderMain.getRepositoryManager(this.repositoryFolder, "native");
+        
+        final LoaderMain loader = new LoaderMain(repositoryManager, new Integer(20), new Integer(10));
+        
+        loader.load(this.testDataFileRdf, "http://test.example.org/test/load/file/native/rdf/base/uri");
+        
+        repositoryManager.shutDown();
+        
+        // NOTE: LoaderMain automatically shuts down the repository after a single call to load
+        
+        // Therefore, it is okay to create another repository manager here
+        
+        final RepositoryManager repositoryManagerAfter =
+                LoaderMain.getRepositoryManager(this.repositoryFolder, "native");
         
         RepositoryConnection afterConnection = null;
         
@@ -424,7 +353,8 @@ public class LoaderMainTest
     public void testLoadInputStreamN3() throws RepositoryException, SailException, FileNotFoundException, IOException,
         RDFParseException, RDFHandlerException, UnsupportedRDFormatException
     {
-        RepositoryManager repositoryManagerBefore = LoaderMain.getRepositoryManager(repositoryFolder, "native");
+        final RepositoryManager repositoryManagerBefore =
+                LoaderMain.getRepositoryManager(this.repositoryFolder, "native");
         
         RepositoryConnection beforeConnection = null;
         
@@ -442,13 +372,11 @@ public class LoaderMainTest
             repositoryManagerBefore.shutDown();
         }
         
-        RepositoryManager repositoryManager = LoaderMain.getRepositoryManager(repositoryFolder, "native");
+        final RepositoryManager repositoryManager = LoaderMain.getRepositoryManager(this.repositoryFolder, "native");
         
-        LoaderMain loader =
-                new LoaderMain(repositoryManager, new Integer(20),
-                        new Integer(10));
+        final LoaderMain loader = new LoaderMain(repositoryManager, new Integer(20), new Integer(10));
         
-        InputStream testResource1 = this.getClass().getResourceAsStream("loadermaintest-1.n3");
+        final InputStream testResource1 = this.getClass().getResourceAsStream("loadermaintest-1.n3");
         
         loader.load(testResource1, RDFFormat.N3, "http://test.example.org/test/load/file/native/rdf/base/uri");
         
@@ -458,7 +386,8 @@ public class LoaderMainTest
         
         // Therefore, it is okay to create another repository manager here
         
-        RepositoryManager repositoryManagerAfter = LoaderMain.getRepositoryManager(repositoryFolder, "native");
+        final RepositoryManager repositoryManagerAfter =
+                LoaderMain.getRepositoryManager(this.repositoryFolder, "native");
         
         RepositoryConnection afterConnection = null;
         
@@ -479,4 +408,108 @@ public class LoaderMainTest
         }
         
     }
+    
+    /**
+     * Test method for
+     * {@link com.github.sesameloader.test.LoaderMain#load(java.io.InputStream, org.openrdf.rio.RDFFormat, java.lang.String)}
+     * .
+     * 
+     * @throws SailException
+     * @throws RepositoryException
+     * @throws IOException
+     * @throws FileNotFoundException
+     * @throws UnsupportedRDFormatException
+     * @throws RDFHandlerException
+     * @throws RDFParseException
+     */
+    @Test
+    public void testLoadInputStreamRdf() throws RepositoryException, SailException, FileNotFoundException, IOException,
+        RDFParseException, RDFHandlerException, UnsupportedRDFormatException
+    {
+        final RepositoryManager repositoryManagerBefore =
+                LoaderMain.getRepositoryManager(this.repositoryFolder, "native");
+        
+        RepositoryConnection beforeConnection = null;
+        
+        try
+        {
+            beforeConnection = repositoryManagerBefore.getConnection();
+            Assert.assertEquals(0, beforeConnection.size());
+        }
+        finally
+        {
+            if(beforeConnection != null)
+            {
+                beforeConnection.close();
+            }
+            repositoryManagerBefore.shutDown();
+        }
+        
+        final RepositoryManager repositoryManager = LoaderMain.getRepositoryManager(this.repositoryFolder, "native");
+        
+        final LoaderMain loader = new LoaderMain(repositoryManager, new Integer(20), new Integer(10));
+        
+        final InputStream testResource1 = this.getClass().getResourceAsStream("loadermaintest-1.rdf");
+        
+        loader.load(testResource1, RDFFormat.RDFXML, "http://test.example.org/test/load/file/native/rdf/base/uri");
+        
+        repositoryManager.shutDown();
+        
+        // NOTE: LoaderMain automatically shuts down the repository after a single call to load
+        
+        // Therefore, it is okay to create another repository manager here
+        
+        final RepositoryManager repositoryManagerAfter =
+                LoaderMain.getRepositoryManager(this.repositoryFolder, "native");
+        
+        RepositoryConnection afterConnection = null;
+        
+        try
+        {
+            afterConnection = repositoryManagerAfter.getConnection();
+            
+            Assert.assertTrue(afterConnection.size() > 0);
+        }
+        finally
+        {
+            if(afterConnection != null)
+            {
+                afterConnection.close();
+            }
+            
+            repositoryManagerAfter.shutDown();
+        }
+        
+    }
+    
+    @Test
+    public void testMaxThreadsFailure() throws SailException, RepositoryException
+    {
+        final String expectedExceptionMessage =
+                "Tried to select more than the maximum number of threads for the given repository manager";
+        
+        final RepositoryManager nextManager = new MaxOneThreadRepositoryManager();
+        
+        try
+        {
+            final LoaderMain loader = new LoaderMain(nextManager, 100, 2);
+            Assert.fail("Did not receive expected exception");
+        }
+        catch(final RuntimeException rex)
+        {
+            Assert.assertTrue(rex.getMessage().contains(expectedExceptionMessage));
+        }
+    }
+    
+    @Test
+    public void testMaxThreadsSuccess() throws SailException, RepositoryException
+    {
+        final String expectedExceptionMessage =
+                "Tried to select more than the maximum number of threads for the given repository manager";
+        
+        final RepositoryManager nextManager = new MaxOneThreadRepositoryManager();
+        
+        final LoaderMain loader = new LoaderMain(nextManager, 100, 1);
+    }
+    
 }

--- a/src/test/java/com/github/sesameloader/test/MaxOneThreadRepositoryManager.java
+++ b/src/test/java/com/github/sesameloader/test/MaxOneThreadRepositoryManager.java
@@ -1,0 +1,44 @@
+/**
+ * 
+ */
+package com.github.sesameloader.test;
+
+import org.openrdf.model.ValueFactory;
+import org.openrdf.repository.RepositoryConnection;
+import org.openrdf.repository.RepositoryException;
+import org.openrdf.sail.SailException;
+
+import com.github.sesameloader.RepositoryManager;
+
+/**
+ * Dummy class used to test the maximum threads restriction.
+ * 
+ * @author Peter Ansell p_ansell@yahoo.com
+ */
+public class MaxOneThreadRepositoryManager implements RepositoryManager
+{
+
+    @Override
+    public RepositoryConnection getConnection() throws RepositoryException
+    {
+        return null;
+    }
+
+    @Override
+    public void shutDown() throws SailException, RepositoryException
+    {
+    }
+
+    @Override
+    public ValueFactory getValueFactory()
+    {
+        return null;
+    }
+
+    @Override
+    public Integer getMaximumThreads()
+    {
+        return 1;
+    }
+    
+}


### PR DESCRIPTION
if maximum threads is set to 0, there is no restriction

some repositories, such as bigdata, do not respond well to being loaded with multiple threads, see my bigdata sesameloader repositorymanager implementation at https://github.com/ansell/bigdata/tree/master/bigdata-sesameloader/src/main/java/com/github/ansell/bigdata/sesameloader for an example of a case where the maximum number of threads needs to be limited to 1 to satisfy the semantics of a bigdata unisolated repository connection

also add test for a limited threads repository manager and a dummy test scope repository manager to use in the test
